### PR TITLE
Upgrade version of Tokio to ^1.0.1

### DIFF
--- a/cargo-bpf/Cargo.toml
+++ b/cargo-bpf/Cargo.toml
@@ -24,7 +24,7 @@ toml_edit = { version = "0.2", optional = true }
 bpf-sys = { version = "^1.3.0", path = "../bpf-sys", optional = true }
 redbpf = { version = "^1.3.0", path = "../redbpf", default-features = false, optional = true }
 futures = { version = "0.3", optional = true }
-tokio = { version = "^0.2.4", features = ["rt-core", "io-driver", "macros", "signal"], optional = true }
+tokio = { version = "^1.0.1", features = ["rt", "macros", "signal"], optional = true }
 hexdump = { version = "0.1", optional = true }
 libc = {version = "0.2.66", optional = true}
 llvm-sys = { version = "110", optional = true}

--- a/cargo-bpf/src/load.rs
+++ b/cargo-bpf/src/load.rs
@@ -12,7 +12,7 @@ use hexdump::hexdump;
 use redbpf::xdp;
 use redbpf::{load::Loader, Program::*};
 use std::path::PathBuf;
-use tokio::runtime::Runtime;
+use tokio::runtime;
 use tokio::signal;
 
 pub fn load(
@@ -21,8 +21,11 @@ pub fn load(
     uprobe_path: Option<&str>,
     pid: Option<i32>,
 ) -> Result<(), CommandError> {
-    let mut runtime = Runtime::new().unwrap();
-    runtime.block_on(async {
+    let rt = runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    rt.block_on(async {
         // Load all the programs and maps included in the program
         let mut loader = Loader::load_file(&program).expect("error loading file");
 

--- a/examples/example-userspace/Cargo.toml
+++ b/examples/example-userspace/Cargo.toml
@@ -10,6 +10,6 @@ cargo-bpf = { version = "", path = "../../cargo-bpf", default-features = false, 
 [dependencies]
 probes = { path = "../example-probes", package = "example-probes" }
 libc = "0.2"
-tokio = { version = "^0.2.4", features = ["signal", "time", "io-util", "tcp", "rt-util", "sync"] }
+tokio = { version = "^1.0.1", features = ["rt", "signal", "time", "io-util", "net", "sync"] }
 redbpf = { version = "", path = "../../redbpf", features = ["load"] }
 futures = "0.3"

--- a/examples/example-userspace/examples/biolatpcts.rs
+++ b/examples/example-userspace/examples/biolatpcts.rs
@@ -4,7 +4,7 @@
 // find another half, a BPF program, at example-probes/biolatpcts/main.rs
 use std::cmp;
 use std::time::Duration;
-use tokio::time::delay_for;
+use tokio::time::sleep;
 
 use redbpf::load::Loader;
 use redbpf::PerCpuArray;
@@ -64,7 +64,7 @@ fn calc_lat_pct(
     return pcts;
 }
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 async fn main() -> ! {
     if unsafe { libc::getuid() != 0 } {
         eprintln!("You must be root to use eBPF!");
@@ -102,7 +102,7 @@ async fn main() -> ! {
     let mut lat_10us = [0; 100];
 
     loop {
-        delay_for(Duration::from_secs(3)).await;
+        sleep(Duration::from_secs(3)).await;
 
         let mut lat_total = 0;
 

--- a/examples/example-userspace/examples/mallocstacks.rs
+++ b/examples/example-userspace/examples/mallocstacks.rs
@@ -7,7 +7,7 @@ use std::process;
 use std::ptr;
 use std::sync::{Arc, Mutex};
 use tokio;
-use tokio::runtime::Runtime;
+use tokio::runtime;
 use tokio::signal;
 
 use redbpf::load::{Loaded, Loader};
@@ -76,7 +76,11 @@ fn main() {
     });
 
     let acc: Acc = Arc::new(Mutex::new(HashMap::new()));
-    let _ = Runtime::new().unwrap().block_on(async {
+    let rt = runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let _ = rt.block_on(async {
         let mut loaded = Loader::load(probe_code()).expect("error loading BPF program");
 
         for prb in loaded.uprobes_mut() {

--- a/examples/example-userspace/examples/tcp-lifetime.rs
+++ b/examples/example-userspace/examples/tcp-lifetime.rs
@@ -23,7 +23,7 @@ use redbpf::HashMap;
 
 use probes::tcp_lifetime::{SocketAddr, TCPLifetime};
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 async fn main() {
     if unsafe { libc::getuid() != 0 } {
         eprintln!("You must be root to use eBPF!");

--- a/redbpf-macros/Cargo.toml
+++ b/redbpf-macros/Cargo.toml
@@ -24,4 +24,4 @@ rustc_version = "0.3.0"
 # redbpf-probes is needed by doctests
 redbpf-probes = { version = "^1.3.0", path = "../redbpf-probes" }
 # memoffset is needed by doctests
-memoffset = "0.5"
+memoffset = "0.6"

--- a/redbpf-probes/Cargo.toml
+++ b/redbpf-probes/Cargo.toml
@@ -21,7 +21,7 @@ quote = "1.0"
 glob = "0.3.0"
 
 [dev-dependencies]
-memoffset = "0.5"
+memoffset = "0.6"
 
 [features]
 default = []

--- a/redbpf-tools/Cargo.toml
+++ b/redbpf-tools/Cargo.toml
@@ -10,7 +10,7 @@ cargo-bpf = { version = "^1.3.0", path = "../cargo-bpf", default-features = fals
 [dependencies]
 probes = { path = "./probes" }
 redbpf = {  version = "^1.3.0", path = "../redbpf", features = ["load"] }
-tokio = { version = "^0.2.4", features = ["rt-core", "io-driver", "macros", "signal", "time"] }
+tokio = { version = "^1.0.1", features = ["rt", "macros", "signal", "time"] }
 futures = "0.3"
 getopts = "0.2"
 libc = "0.2"

--- a/redbpf-tools/src/bin/redbpf-iotop.rs
+++ b/redbpf-tools/src/bin/redbpf-iotop.rs
@@ -13,9 +13,9 @@ use std::os::raw::c_char;
 use std::process;
 use std::time::Duration;
 use tokio;
-use tokio::runtime::Runtime;
+use tokio::runtime;
 use tokio::signal;
-use tokio::time::delay_for;
+use tokio::time::sleep;
 
 use probes::iotop::{Counter, CounterKey};
 
@@ -25,8 +25,11 @@ fn main() {
         process::exit(-1);
     }
 
-    let mut runtime = Runtime::new().unwrap();
-    let _ = runtime.block_on(async {
+    let rt = runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let _ = rt.block_on(async {
         // load the BPF programs and maps
         let mut loader = Loader::load(probe_code()).expect("error loading probe");
 
@@ -43,7 +46,7 @@ fn main() {
             let disks = parse_diskstats().unwrap();
 
             loop {
-                delay_for(Duration::from_millis(1000)).await;
+                sleep(Duration::from_millis(1000)).await;
 
                 println!(
                     "{:6} {:16} {:1} {:3} {:3} {:8} {:>5} {:>7} {:>6}",

--- a/redbpf-tools/src/bin/redbpf-tcp-knock.rs
+++ b/redbpf-tools/src/bin/redbpf-tcp-knock.rs
@@ -12,7 +12,7 @@ use std::net::Ipv4Addr;
 use std::process;
 use std::ptr;
 use tokio;
-use tokio::runtime::Runtime;
+use tokio::runtime;
 use tokio::signal;
 
 use probes::knock::{Connection, KnockAttempt, PortSequence, MAX_SEQ_LEN};
@@ -28,8 +28,11 @@ fn main() {
         None => process::exit(1),
     };
 
-    let mut runtime = Runtime::new().unwrap();
-    let _ = runtime.block_on(async {
+    let rt = runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let _ = rt.block_on(async {
         let mut loader = Loader::load(probe_code()).expect("error loading probe");
 
         // attach the xdp program

--- a/redbpf/Cargo.toml
+++ b/redbpf/Cargo.toml
@@ -30,7 +30,7 @@ ring = { version = "0.16", optional = true }
 
 futures = { version = "0.3", optional = true }
 mio = { version = "0.6", optional = true }
-tokio = { version = "^0.2.4", features = ["rt-core", "io-driver", "macros", "signal"], optional = true }
+tokio = { version = "^1.0.1", features = ["rt", "macros", "signal", "net"], optional = true }
 
 [features]
 default = []


### PR DESCRIPTION
This resolves #129 issue.
All example programs work as expected.
All packages of workspace are compiled successfully with stable rust 1.51.0.