### PR TITLE
Fix mismatched types in biolatpcts example

### DIFF
--- a/examples/example-probes/src/biolatpcts/main.rs
+++ b/examples/example-probes/src/biolatpcts/main.rs
@@ -41,7 +41,7 @@ fn blk_account_io_done(regs: Registers) {
     let dur = now - stime;
     let slot = cmp::min(dur / (100 * NSEC_PER_MSEC) as u64, 99);
     unsafe {
-        match LAT_100MS.get_mut(slot as i32) {
+        match LAT_100MS.get_mut(slot as u32) {
             Some(mut val) => *val += 1,
             _ => (),
         }
@@ -52,7 +52,7 @@ fn blk_account_io_done(regs: Registers) {
 
     let slot = cmp::min(dur / NSEC_PER_MSEC as u64, 99);
     unsafe {
-        match LAT_1MS.get_mut(slot as i32) {
+        match LAT_1MS.get_mut(slot as u32) {
             Some(mut val) => *val += 1,
             _ => (),
         }
@@ -63,7 +63,7 @@ fn blk_account_io_done(regs: Registers) {
 
     let slot = cmp::min(dur / (10 * NSEC_PER_USEC) as u64, 99);
     unsafe {
-        match LAT_10US.get_mut(slot as i32) {
+        match LAT_10US.get_mut(slot as u32) {
             Some(mut val) => *val += 1,
             _ => (),
         }


### PR DESCRIPTION
When I run `cargo build --examples`, I get this error: 

```
  error[E0308]: mismatched types
    --> examples/example-probes/src/biolatpcts/main.rs:66:32
     |
  66 |         match LAT_10US.get_mut(slot as i32) {
     |                                ^^^^^^^^^^^ expected `u32`, found `i32`
     |
```

This updates the types in the example so that it compiles.

I think this is because the examples didn't get updated after this change by @belltoy https://github.com/ingraind/redbpf/commit/ae93e255ad54e8d0b5fcd96ce939b050c2ba67cc